### PR TITLE
fix: Remove `@expo/config-plugins` peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "typescript-eslint": "^8.24.1"
       },
       "peerDependencies": {
-        "@expo/config-plugins": "*",
         "expo": "*",
         "expo-build-properties": ">=1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -69,8 +69,7 @@
   },
   "peerDependencies": {
     "expo": "*",
-    "expo-build-properties": ">=1.0.0",
-    "@expo/config-plugins": "*"
+    "expo-build-properties": ">=1.0.0"
   },
   "react-native-builder-bob": {
     "source": "./plugin",

--- a/plugin/ios/utils/project.ts
+++ b/plugin/ios/utils/project.ts
@@ -1,6 +1,6 @@
 import { readdirSync } from 'node:fs';
 
-import type { XcodeProject } from '@expo/config-plugins';
+import type { XcodeProject } from 'expo/config-plugins';
 
 import type { Group, PbxGroup, Target } from '../types';
 import { readFromTemplate } from '../utils';


### PR DESCRIPTION
## Summary

From Expo's dependency tree's perspective, a peer on `@expo/config-plugins` isn't desirable, as it's expected to match an internal version tied to the `expo` version, meaning:
- adding a top-level dependency on it will cause an error by `expo-doctor`
- adding a top-level dependency on it may mismatch `expo`'s version of the config plugins package
- leaving it out relies on hoisting and will fail with isolated dependency installations or warn/error depending on the package manager

Our intention is for `expo/config-plugins` to be the only necessary entrypoint and for this to remain stable in SDK versions (major releases)

Since this is already used consistently, the peer shouldn't be necessary, but let me know if that is causing any issues or has caused issues in the past

## Set of changes

- Remove `@expo/config-plugins` peer dep entry
- Replace leftover `@expo/config-plugins` import (despite it being type-only) with `expo/config-plugins`