### PR TITLE
fix: use configuration variable instead of hardcoded Release in iOS build paths

### DIFF
--- a/plugin/src/cli/build-ios.ts
+++ b/plugin/src/cli/build-ios.ts
@@ -130,9 +130,9 @@ const packageFrameworks = async (config: BuildConfigIOS) => {
     [
       '-create-xcframework',
       '-framework',
-      `${config.derivedDataPath}/Build/Products/Release-iphoneos/${config.scheme}.framework`,
+      `${config.derivedDataPath}/Build/Products/${config.configuration}-iphoneos/${config.scheme}.framework`,
       '-framework',
-      `${config.derivedDataPath}/Build/Products/Release-iphonesimulator/${config.scheme}.framework`,
+      `${config.derivedDataPath}/Build/Products/${config.configuration}-iphonesimulator/${config.scheme}.framework`,
       '-output',
       `${config.artifactsDir}/${config.scheme}.xcframework`,
     ],


### PR DESCRIPTION
## Summary
- Updated framework paths in `packageFrameworks` to use `config.configuration` instead of hardcoded "Release" values
- Allows for dynamic build configurations (Debug, Release, etc.) when packaging XCFrameworks

## Changes
This PR fixes the iOS build process to respect the build configuration parameter instead of hardcoding "Release" in the framework paths.

## Test plan
- [x] Build iOS frameworks with Release configuration
- [x] Build iOS frameworks with Debug configuration
- [x] Verify XCFramework artifacts are created correctly in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)