### PR TITLE
Fix `popToNative()` not always returning to the native app on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,11 @@ if (useManagedAndroidSdkVersions) {
   }
 }
 
+dependencies {
+  compileOnly "androidx.activity:activity-ktx:1.8.0"
+  compileOnly "androidx.core:core-ktx:1.12.0"
+}
+
 android {
   namespace "expo.modules.brownfield"
   defaultConfig {

--- a/android/src/main/java/expo/modules/brownfield/ExpoBrownfieldModule.kt
+++ b/android/src/main/java/expo/modules/brownfield/ExpoBrownfieldModule.kt
@@ -1,5 +1,6 @@
 package expo.modules.brownfield
 
+import androidx.activity.ComponentActivity
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
@@ -13,8 +14,13 @@ class ExpoBrownfieldModule : Module() {
 
     Function("popToNative") { animated: Boolean ->
       appContext.currentActivity?.runOnUiThread {
-        @Suppress("DEPRECATION")
-        appContext.currentActivity?.onBackPressed()
+        val componentActivity = appContext.currentActivity as? ComponentActivity
+        if (componentActivity != null) {
+          val enabled = BrownfieldNavigationState.nativeBackEnabled
+          BrownfieldNavigationState.nativeBackEnabled = true
+          componentActivity.onBackPressedDispatcher?.onBackPressed()
+          BrownfieldNavigationState.nativeBackEnabled = enabled
+        }
       }
     }
 


### PR DESCRIPTION
### Problem

In my demo app returning to native from the first screen works fine if we're on the first screen because `nativeBackEnabled` is set to `false`. Returning to native from any further screen only returns within the React Native app because we're setting `nativeBackEnabled` to `true` based on navigation state. `popToNative` should always pop to the host app regardless of navigation state and back handling enablement.

### Fix

Temporarily force `BrownfieldNavigationState.nativeBackEnabled` to be `true` while pop to the native is performed, then restore the previous value. Also updated `popToNative` to use the new back press dispatcher API instead of the deprecated method.

### Previous behavior

https://github.com/user-attachments/assets/f059663f-7201-42ff-b51c-c83d8e43c351

### New behavior

https://github.com/user-attachments/assets/65a05fdb-fdb2-4d04-bcab-89b67b3f8410